### PR TITLE
Add Pease.day to related products section

### DIFF
--- a/src/components/RelatedProducts.astro
+++ b/src/components/RelatedProducts.astro
@@ -30,6 +30,19 @@
           <span>了解更多 →</span>
         </div>
       </a>
+
+      <a href="https://pease.day" class="product-card" target="_blank" rel="noopener">
+        <div class="product-content">
+          <div class="product-header">
+            <img src="https://pease.day/icon-128x128.png" alt="Pease Logo" class="product-logo no-bg" />
+            <h3>Pease</h3>
+          </div>
+          <p>美观简约的环境音混音器，为专注、放松或睡眠创造完美的声音环境</p>
+        </div>
+        <div class="cta">
+          <span>了解更多 →</span>
+        </div>
+      </a>
     </div>
   </div>
 </section> 

--- a/src/styles/related-products.css
+++ b/src/styles/related-products.css
@@ -20,17 +20,19 @@
 }
 
 .product-card {
-    @apply p-8 rounded-2xl bg-white/[0.02]
-    border border-zinc-800
-    transition-all relative
-    hover:bg-zinc-900 hover:border-zinc-700
-    transform hover:-translate-y-1;
-  transition: all 0.3s ease;
+    padding: 2rem;
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgb(39, 39, 42);
+    transition: all 0.3s ease;
+    position: relative;
 }
 
 .product-card:hover {
     transform: translateY(-8px);
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+    background: rgb(24, 24, 27);
+    border-color: rgb(63, 63, 70);
 }
 
 .product-header {
@@ -47,6 +49,11 @@
   background: #fff;
   padding: 6px;
   object-fit: contain;
+}
+
+.product-logo.no-bg {
+  background: transparent;
+  padding: 0;
 }
 
 .product-content h3 {
@@ -101,5 +108,9 @@
     width: 40px;
     height: 40px;
     padding: 4px;
+  }
+
+  .product-logo.no-bg {
+    padding: 0;
   }
 } 


### PR DESCRIPTION
## Summary
- Added Pease.day product card to the related products section
- Fixed border radius styling issues for product cards
- Added special styling for logos with existing backgrounds

## Changes
- Added Pease product with ambient sound mixer description
- Converted Tailwind @apply styles to regular CSS for better consistency
- Added `.no-bg` class for logos that already have backgrounds

## Test plan
- [x] Verify Pease product card displays correctly
- [x] Check border radius is properly applied to all cards
- [x] Confirm Pease logo displays without extra background
- [x] Test responsive design on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)